### PR TITLE
feat: revalidate Dockerfile on config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Revalidate all Dockerfile when `.hadolint.yaml` is changed
+
+
 ## [0.2.3] - 2018-11-28
 
 ### Changed

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,6 +25,7 @@ export function activate(context: ExtensionContext) {
       // Synchronize the setting section 'languageServerExample' to the server
       configurationSection: 'hadolint',
       // Notify the server about file changes to '.clientrc files contain in the workspace
+      // TODO: add handling for custom hadolint config file location
       fileEvents: workspace.createFileSystemWatcher('**/.hadolint.yaml')
     }
   };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -116,8 +116,11 @@ connection.onDidChangeConfiguration((change) => {
 });
 
 connection.onDidChangeWatchedFiles((_change) => {
-  // Monitored files have change in VSCode
-  connection.console.log('We received an file change event');
+  // Detect .hadolint.yaml change
+  // revalidate all documents
+  documents.all().forEach(document => {
+    validateTextDocument(document);
+  });
 });
 
 // Listen on the connection


### PR DESCRIPTION
When language server detects .hadolint.yaml file is changed, simply revalidate all documents